### PR TITLE
Define STRICT_R_HEADERS, include float.h for DBL_MIN

### DIFF
--- a/src/nnlib2.h
+++ b/src/nnlib2.h
@@ -29,6 +29,8 @@
 /*-----------------------------------------------------------------------*/
 
 #ifdef NNLIB2_FOR_RCPP
+#define STRICT_R_HEADERS
+#include <float.h>
 #include <Rcpp.h>
 // [[Rcpp::plugins("cpp11")]]
 using namespace Rcpp;


### PR DESCRIPTION
Dear Vasilis,

Your CRAN package nnlib2Rcpp uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context on this.

Because you have a (convenient !!) central header file, we can just prefix #include <Rcpp.h> with STRICT_R_HEADERS and included float.h (alternatively cfloat could be used for C++ style, it's equivalent).  No other changes are needed.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging byhttps://github.com/RcppCore/Rcpp/issues/1158 to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.